### PR TITLE
index.html: fix Rust and Java order

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@ layout: default
     <article>
       <h2>Libraries</h2>
       <ul>
-        <li>Java: <a href="https://github.com/dirs-dev/directories-rs">dirs-dev/directories-rs</a> <a href="https://github.com/dirs-dev/dirs-rs">dirs-dev/dirs-rs</a></li>
-        <li>Rust: <a href="https://github.com/dirs-dev/directories-jvm">dirs-dev/directories-jvm</a></li>
+        <li>Rust: <a href="https://github.com/dirs-dev/directories-rs">dirs-dev/directories-rs</a> <a href="https://github.com/dirs-dev/dirs-rs">dirs-dev/dirs-rs</a></li>
+        <li>Java: <a href="https://github.com/dirs-dev/directories-jvm">dirs-dev/directories-jvm</a></li>
       </ul>
     </article>
   </section>


### PR DESCRIPTION
List of links to GitHub has Java and Rust libraries backwards.  Fix it
by swapping the text before the links around.